### PR TITLE
docs: fix simple typo, somtehing -> something

### DIFF
--- a/cpp/class.cpp
+++ b/cpp/class.cpp
@@ -704,7 +704,7 @@ class CopyAndSwap {
         - there is no `Iterator` interface that iterates over anything in the stdlib
             for performance reasons.
 
-            By iterable understand somtehing that has an `::iterator`,
+            By iterable understand something that has an `::iterator`,
             a `begin()` and an `end()` methods, like stl containers
         */
         class VisibleInnerIterable {


### PR DESCRIPTION
There is a small typo in cpp/class.cpp.

Should read `something` rather than `somtehing`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md